### PR TITLE
Add more split data (RPX and SPPX)

### DIFF
--- a/components/Tooltips.jsx
+++ b/components/Tooltips.jsx
@@ -4,6 +4,9 @@ export const SplitInfoTooltips = () => (
   <>
     <ReactTooltip id="cumulative">Cumulative/Standard</ReactTooltip>
     <ReactTooltip id="relative">Relative to previous split</ReactTooltip>
+    <ReactTooltip id="xph">splits per hour</ReactTooltip>
+    <ReactTooltip id="rpx">resets per split</ReactTooltip>
+    <ReactTooltip id="sppx">seeds played per split</ReactTooltip>
   </>
 )
 

--- a/components/user/figures/SplitInfo.jsx
+++ b/components/user/figures/SplitInfo.jsx
@@ -11,37 +11,45 @@ const SplitInfo = ({ splitName, splitData }) => {
             <Table className="mb-4" style={{ fontSize: "1.35em" }} responsive bordered hover variant="light">
                 <thead>
                     <tr>
+                        <th data-tip data-for="xph">XPH</th>
                         <th>Count</th>
                         <th>Average</th>
                         <th>Stdev</th>
                         <th>Rate</th>
-                        <th>XPH</th>
+                        <th data-tip data-for="sppx">SPPX</th>
+                        <th data-tip data-for="rpx">RPX</th>
                     </tr>
                 </thead>
                 <tbody style={{ fontFamily: "Roboto", fontSize: "1em" }}>
                     <tr data-tip data-for="cumulative">
+                        <td>{roundToPerc(splitData.xph)}</td>
                         <td>{roundToPerc(splitData.total)}</td>
                         <td>{splitData.time > 0 ? msToStr(splitData.time) : "-----"}</td>
                         <td>{splitData.cStdev > 0 ? msToStr(splitData.cStdev) : "-----"}</td>
                         <td>{!isNaN(roundToPerc(splitData.cConv * 100)) ? `${roundToPerc(splitData.cConv * 100)}%` : "-----"}</td>
-                        <td>{roundToPerc(splitData.xph)}</td>
+                        <td>{roundToPerc(splitData.sppx)}</td>
+                        <td>{splitData.rpx}</td>
                     </tr>
                     {
                         (
                             (splitName === "Iron") ? (
                                 <tr data-tip data-for="relative" style={{ color: "#888" }}>
                                     <td></td>
+                                    <td></td>
                                     <td>-----</td>
                                     <td>-----</td>
                                     <td>-----</td>
+                                    <td></td>
                                     <td></td>
                                 </tr>
                             ) : (
                                 <tr data-tip data-for="relative" style={{ color: "#888" }}>
                                     <td></td>
+                                    <td></td>
                                     <td>{splitData.tsp > 0 ? msToStr(splitData.tsp) : "-----"}</td>
                                     <td>{splitData.rStdev > 0 ? msToStr(splitData.rStdev) : "-----"}</td>
                                     <td>{!isNaN(roundToPerc(splitData.rConv * 100)) ? `${roundToPerc(splitData.rConv * 100)}%` : "-----"}</td>
+                                    <td></td>
                                     <td></td>
                                 </tr>
                             )

--- a/public/helpers/dataOperations.js
+++ b/public/helpers/dataOperations.js
@@ -338,13 +338,15 @@ export const doAllOps = (data, keepSessions = []) => {
   let prevCount = resetCount
   timelines.forEach(tItem => {
     if (!currTimeline.hasOwnProperty(tItem))
-      finalTimeline.push({ time: 0, total: 0, tsp: 0, XPH: 0, cStdev: 0, rStdev: 0, cDist: [], rDist: [], cConv: 0, rConv: 0 })
+      finalTimeline.push({ time: 0, total: 0, tsp: 0, xph: 0, rpx: 0, sppx: 0, cStdev: 0, rStdev: 0, cDist: [], rDist: [], cConv: 0, rConv: 0 })
     else
       finalTimeline.push({
         time: Math.round(mean(currTimeline[tItem].cDist)),
         total: currTimeline[tItem].cDist.length,
         tsp: Math.round(mean(currTimeline[tItem].rDist)),
         xph: (currTimeline[tItem] ? currTimeline[tItem].cDist.length / (currTimeline[tItem].preSplitRTA / 1000 / 60 / 60) : 0),
+        rpx: Math.round(resetCount / currTimeline[tItem].cDist.length),
+        sppx: seedsPlayed / currTimeline[tItem].cDist.length,
         cStdev: Math.round(stdev(currTimeline[tItem].cDist)),
         rStdev: Math.round(stdev(currTimeline[tItem].rDist)),
         cDist: processLinePlotData(currTimeline[tItem].cDist),


### PR DESCRIPTION
Useful stats to compare with other runners, tells you if you are missing BTs and/or enters.
I moved XPH to the start of the table because it looked too cluttered when they XPH, RPX and SPPX were so close together ¯\\\_(ツ)_/¯
I also added tooltips for XPH, RPX and SPPX because the acronyms are confusing

![image](https://github.com/Specnr/ResetAnalytics/assets/87690741/fca2f169-a5da-4ff0-8f93-dbe90f3d934d)
